### PR TITLE
Feat: auto crawling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "an-array-of-english-words": "^2.0.0",
+        "axios": "^1.6.7",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
@@ -2135,8 +2136,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
@@ -2158,6 +2158,16 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2844,7 +2854,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3205,7 +3214,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4878,6 +4886,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4910,7 +4937,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "an-array-of-english-words": "^2.0.0",
+    "axios": "^1.6.7",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",

--- a/src/crawler/combineScores.js
+++ b/src/crawler/combineScores.js
@@ -23,21 +23,19 @@ async function combinePageRankAndBM25() {
           (videoOne, videoTwo) => videoTwo.score - videoOne.score,
         );
 
-        console.log(keyword.text);
         await keyword.save();
       }),
     );
   } catch (error) {
     console.error(error);
   }
+
   console.log("Finish Ranking for all keywords");
 }
 
 async function combineScores() {
   await mongooseLoader();
-  const start = Date.now();
   await combinePageRankAndBM25();
-  console.log(Date.now() - start);
 }
 
 combineScores();

--- a/src/crawler/setPageRank.js
+++ b/src/crawler/setPageRank.js
@@ -29,10 +29,7 @@ async function setForwardLinks() {
         }),
       );
 
-      await Video.findOneAndUpdate(
-        { youtubeVideoId: video.youtubeVideoId },
-        { forwardLinks },
-      );
+      await Video.findByIdAndUpdate(video._id, { forwardLinks });
     });
 
     await Promise.all(videosPromises);
@@ -80,10 +77,7 @@ async function calculatePageRank() {
     videos.map(async (video, index) => {
       const pageRankScore = pageRank.toArray()[index];
 
-      await Video.findOneAndUpdate(
-        { youtubeVideoId: video.youtubeVideoId },
-        { pageRankScore },
-      );
+      await Video.findOneAndUpdate(video._id, { pageRankScore });
     }),
   );
 }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -8,5 +8,6 @@ router.get("/streamCrawling", crawlingController.streamCrawling);
 router.get("/startCrawling", crawlingController.startCrawling);
 router.get("/stopCrawling", crawlingController.stopCrawling);
 router.get("/verifyYoutubeUrl", crawlingController.verifyYoutubeUrl);
+router.post("/autoCrawling", crawlingController.autoCrawling);
 
 module.exports = router;


### PR DESCRIPTION
### [[BE] 크롤링 자동화 ](https://www.notion.so/seongjunhong/BE-4e65d36afc384da2b9ff2fd41a38470b?pvs=4)

### description

- aws lambda 함수 생성
    - 연관 검색어 링크 가져오기, 비디오 데이터 가져오기, 비디오 점수 계산 및 db저장 총 3개, 30초 시간 제한이 있어 분리하여 진행했습니다.
    - lambda를 이용하여 특정 트리거(사용자가 비디오를 시청하러 비디오 디테일 페이지로 이동)시 연관 비디오를 크롤링합니다.
    - api gateway를 이용하여 서버에서 api호출하였습니다.
- 사용자가 동영상을 시청하면 트리거 발동
- 글로벌 상태를 이용하여 클라이언트 별로 트리거 연속 발동 방지

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.
