### PR TITLE
Feat: enable logged-in user to delete search history

### DIFF
--- a/src/constants/imageConstants.js
+++ b/src/constants/imageConstants.js
@@ -1,7 +1,0 @@
-const IMAGE_WIDTH = 1452;
-const IMAGE_HEIGHT = 816;
-
-module.exports = {
-  IMAGE_WIDTH,
-  IMAGE_HEIGHT,
-};

--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -92,7 +92,7 @@ exports.getAutoCompletions = async function (req, res, next) {
 };
 
 exports.deleteAutoCompletions = async function (req, res, next) {
-  const { history } = req.query;
+  const { historyToDelete } = req.query;
   const { accessToken } = req.cookies;
   const decodedToken = jwt.decode(accessToken);
   const { userId } = decodedToken;
@@ -100,8 +100,7 @@ exports.deleteAutoCompletions = async function (req, res, next) {
   const user = await User.findOne({
     _id: userId,
   });
-
-  const privateHistoryIndex = user.searchHistory.indexOf(history);
+  const privateHistoryIndex = user.searchHistory.indexOf(historyToDelete);
 
   user.searchHistory.splice(privateHistoryIndex, 1);
   user.save();

--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -55,6 +55,7 @@ exports.getAutoCompletions = async function (req, res, next) {
     return res.status(200).send({
       result: "ok",
       searchHistories: userSearchHistory.slice(0, MAXIMUM_AUTO_COMPLETIONS),
+      referenceIndex: MAXIMUM_AUTO_COMPLETIONS,
     });
   }
 

--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -98,13 +98,11 @@ exports.deleteAutoCompletions = async function (req, res, next) {
   const decodedToken = jwt.decode(accessToken);
   const { userId } = decodedToken;
 
-  const user = await User.findOne({
-    _id: userId,
-  });
+  const user = await User.findById(userId);
   const privateHistoryIndex = user.searchHistory.indexOf(historyToDelete);
 
   user.searchHistory.splice(privateHistoryIndex, 1);
-  user.save();
+  await user.save();
 
   return res.status(200).json({
     result: "ok",

--- a/src/routes/autoCompletions.js
+++ b/src/routes/autoCompletions.js
@@ -8,4 +8,10 @@ const router = express.Router();
 
 router.get("/", verifyToken, autoCompletionsController.getAutoCompletions);
 
+router.delete(
+  "/",
+  verifyToken,
+  autoCompletionsController.deleteAutoCompletions,
+);
+
 module.exports = router;

--- a/src/utils/checkSpelling.js
+++ b/src/utils/checkSpelling.js
@@ -5,6 +5,9 @@ const Trie = require("./trie");
 
 const trie = new Trie();
 const validWords = [...englishWords, ...jsWords];
+const MIN_SIMILARITY_SCORE = 0.7;
+const SOUNDEX_MATCH_CONSTANT = 1;
+const SOUNDEX_UNMATCH_CONSTANT = 0.5;
 
 validWords.forEach((word) => trie.insert(word.toLowerCase()));
 
@@ -86,10 +89,12 @@ function checkSpell(misspelledWord) {
     const union = new Set([...biGramsOfMisspelledWord, ...biGramsOfCorrectWord])
       .size;
     const jaccardSimilarity = intersection / union;
-    const soundexMatch = misspelledSoundex === correctSoundex;
-    const similarityScore = jaccardSimilarity * (soundexMatch ? 1 : 0.5);
+    const isSoundexMatch = misspelledSoundex === correctSoundex;
+    const similarityScore =
+      jaccardSimilarity *
+      (isSoundexMatch ? SOUNDEX_MATCH_CONSTANT : SOUNDEX_UNMATCH_CONSTANT);
 
-    if (similarityScore > 0.5) {
+    if (similarityScore > MIN_SIMILARITY_SCORE) {
       suggestions.push({
         word: correctWord,
         similarityScore,
@@ -107,6 +112,8 @@ function checkUserInputSpelling(userInput) {
   const output = [];
   userInputArray.forEach((word) => {
     if (trie.search(word)) {
+      output.push(word);
+    } else if (checkSpell(word) === undefined) {
       output.push(word);
     } else {
       output.push(checkSpell(word).word);

--- a/src/utils/fetchVideosRanks.js
+++ b/src/utils/fetchVideosRanks.js
@@ -23,7 +23,7 @@ async function fetchVideosRanks(query) {
       results[video.youtubeVideoId] = parseFloat(video.score);
     });
   } catch (error) {
-    console.error(error);
+    console.error(error.message);
 
     return [];
   }


### PR DESCRIPTION
### [[FE/BE] 로그인 유저 자동 완성 삭제 기능](https://www.notion.so/seongjunhong/FE-BE-54fd83248f534c55a4132d1f302b4b48?pvs=4)

### 작업한 내용
1. 로그인한 사용자의 검색 기록을 삭제하는 로직을 추가하였습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### etc

현재 `an-array-of-english-words` 라이브러리 기준으로 스팰링 체크 여부를 확인하기에, 아래 케이스에서 정상 작동 하지 않는 점을 확인.
1. 2024 (숫자만)
2. iphone15 (문자+숫자; 스페이스 없이)
3. korean, korea (현재 이런 단어들도 라이브러리에 없는 것으로 확인)