### PR TITLE
Fix: documentLength schema

### DIFF
--- a/src/models/DocumentLength.js
+++ b/src/models/DocumentLength.js
@@ -1,3 +1,4 @@
+const { Decimal128 } = require("mongodb");
 const mongoose = require("mongoose");
 
 const documentLengthSchema = new mongoose.Schema({
@@ -7,23 +8,23 @@ const documentLengthSchema = new mongoose.Schema({
     required: true,
   },
   documentLength: {
-    type: Number,
+    type: Decimal128,
     required: true,
   },
   titleLength: {
-    type: Number,
+    type: Decimal128,
     required: true,
   },
   descriptionLength: {
-    type: Number,
+    type: Decimal128,
     required: true,
   },
   transcriptLength: {
-    type: Number,
+    type: Decimal128,
     required: true,
   },
   tagLength: {
-    type: Number,
+    type: Decimal128,
     required: true,
   },
 });

--- a/src/utils/calculateScore.js
+++ b/src/utils/calculateScore.js
@@ -15,9 +15,7 @@ function calculateBM25(IDF, TF, documentLength, averageDocumentLength) {
 }
 
 exports.calculateAverage = function (prevAverage, totalCount, documentLength) {
-  return Math.floor(
-    (prevAverage * (totalCount - 1) + documentLength) / totalCount,
-  );
+  return (prevAverage * (totalCount - 1) + documentLength) / totalCount;
 };
 
 exports.calculateIDF = function (totalDocuments, documents) {
@@ -42,28 +40,28 @@ exports.calculateBM25F = function (
         IDF,
         TFs.titleTF,
         fieldTokens.titleTokens.length,
-        averageDocumentLength.titleLength,
+        parseInt(averageDocumentLength.titleLength, 10),
       ) +
     DESCRIPTION_WEIGHT *
       calculateBM25(
         IDF,
         TFs.descriptionTF,
         fieldTokens.descriptionTokens.length,
-        averageDocumentLength.descriptionLength,
+        parseInt(averageDocumentLength.descriptionLength, 10),
       ) +
     TRANSCRIPT_WEIGHT *
       (calculateBM25(
         IDF,
         TFs.transcriptTF,
         fieldTokens.transcriptTokens.length,
-        averageDocumentLength.transcriptLength,
+        parseInt(averageDocumentLength.transcriptLength, 10),
       ) || 0) +
     TAG_WEIGHT *
       (calculateBM25(
         IDF,
         TFs.tagTF,
         fieldTokens.tagTokens.length,
-        averageDocumentLength.tagLength,
+        parseInt(averageDocumentLength.tagLength, 10),
       ) || 0);
 
   return score;


### PR DESCRIPTION
### description

- 비디오 크롤링 중 평균 document길이가 0이 되는 문제 해결
  - 기존 data type이 number로 Math.floor로 평균을 버림한 결과 평균 값이 점점 작아져 0이 되는 문제가 생겼습니다.
  - data type을 decimal128로 수정하여 정확한 평균값을 구하였습니다. 


### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.
