### PR TITLE
Fix: add parseFloat on decimal128 Type

### DIFF
--- a/src/crawler/insertIntoDB.js
+++ b/src/crawler/insertIntoDB.js
@@ -130,7 +130,7 @@ async function saveKeywords(video, words, originalWords, fieldTokens, session) {
       });
 
       keyword.videos = keyword.videos.sort(
-        (videoOne, VideoTwo) => VideoTwo.scoreBM - videoOne.scoreBM,
+        (videoOne, VideoTwo) => VideoTwo.score - videoOne.score,
       );
       keyword.IDF = inverseDocumentFrequency;
 

--- a/src/utils/calculateScore.js
+++ b/src/utils/calculateScore.js
@@ -38,28 +38,28 @@ exports.calculateBM25F = function (
     TITLE_WEIGHT *
       calculateBM25(
         IDF,
-        TFs.titleTF,
+        parseFloat(TFs.titleTF),
         fieldTokens.titleTokens.length,
         parseInt(averageDocumentLength.titleLength, 10),
       ) +
     DESCRIPTION_WEIGHT *
       calculateBM25(
         IDF,
-        TFs.descriptionTF,
+        parseFloat(TFs.descriptionTF),
         fieldTokens.descriptionTokens.length,
         parseInt(averageDocumentLength.descriptionLength, 10),
       ) +
     TRANSCRIPT_WEIGHT *
       (calculateBM25(
         IDF,
-        TFs.transcriptTF,
+        parseFloat(TFs.transcriptTF),
         fieldTokens.transcriptTokens.length,
         parseInt(averageDocumentLength.transcriptLength, 10),
       ) || 0) +
     TAG_WEIGHT *
       (calculateBM25(
         IDF,
-        TFs.tagTF,
+        parseFloat(TFs.tagTF),
         fieldTokens.tagTokens.length,
         parseInt(averageDocumentLength.tagLength, 10),
       ) || 0);


### PR DESCRIPTION
### description

- term frequency를 구하는 로직을 수정하면서 data schema type을 decimal128로 수정하였습니다.
- 수정 후 연산 과정에서 타입이 맞지 않아 NaN, 0이 값이 나오는 문제가 생겼습니다. 
- parseFloat로 타입을 변경 후 연산하여 해결했습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.